### PR TITLE
mn5: add chemshell program preset for QM/MM on GPP

### DIFF
--- a/bsc_calculations/mn5.py
+++ b/bsc_calculations/mn5.py
@@ -167,6 +167,7 @@ def jobArrays(
         "RFDiffusion",
         "bioemu_af",
         "cp2k",
+        "chemshell",
         "boltz2",
         "ligandmpnn",
         "mlcg",
@@ -401,6 +402,54 @@ def jobArrays(
             sources = []
         sources.append('/gpfs/projects/bsc72/Programs/cp2k-2025.2/tools/toolchain/install/setup')
         pathMN.append("/gpfs/projects/bsc72/Programs/cp2k-2025.2.clean/exe/local")
+
+    if program == "chemshell":
+        # Py-ChemShell 25.0.5 on MN5 GPP, built against openmpi/4.1.5-gcc
+        # with a linked DL_POLY 5.1.0 from /gpfs/projects/bsc72/mfloor/
+        # dl-poly. The chemsh.x binary calls ORCA 5.0.3 by system() for
+        # the QM step and invokes the linked libdl_poly.so via runLib()
+        # for the MM step (so MM energies populate); the full build
+        # recipe lives in the project's mn5_chemshell_mpi_build memo.
+        #
+        # Sizing (80-atom QM region under B3LYP/def2-SVP/D3BJ/RIJCOSX/
+        # TightSCF on a 63 k-atom solvated substrate, benched 2026-06-13):
+        # the DL_POLY linked-library path peaks at ~156 GB resident, so
+        # ``cpus-per-task=32`` on the highmem partition (8 GB/cpu ->
+        # 256 GB) is the minimum that survives without OOM. ORCA's MPI
+        # scaling saturates at ``nprocs=4`` for this QM region; the
+        # validated optimum is ``cpus-per-task=32`` + ``nprocs=4`` +
+        # ``OMP_NUM_THREADS=8`` (= 4x8 = 32 threads), giving ~9 min wall
+        # per QM/MM SP+gradient, matched by every larger allocation
+        # tested up to a full 112-core node.
+        module_purge = True
+        chemsh_modules = ['openmpi/4.1.5-gcc', 'orca/5.0.3']
+        if modules is None:
+            modules = chemsh_modules
+        else:
+            modules += chemsh_modules
+        if exports is None:
+            exports = []
+        # The orca/5.0.3 module's prepend_path on LD_LIBRARY_PATH does
+        # not always survive a module-purge-clean environment, so export
+        # the ORCA library dir explicitly. Without this orca crashes
+        # with "liborca_tools_5_0_3.so.5: cannot open shared object
+        # file" on the first QM step.
+        exports.append('ORCA_BIN=/apps/GPP/ORCA/5.0.3/OPENMPI/orca')
+        exports.append('LD_LIBRARY_PATH=/apps/GPP/ORCA/5.0.3/OPENMPI:${LD_LIBRARY_PATH}')
+        exports.append('CHEMSH_ROOT=/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5')
+        exports.append('CHEMSH_ARCH=gnu')
+        # The chemsh.x launcher, ORCA binaries and the patched DL_POLY
+        # binaries on PATH so ``chemsh system.py`` and the downstream
+        # tools resolve directly.
+        pathMN.append('/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5/bin/gnu')
+        pathMN.append('/apps/GPP/ORCA/5.0.3/OPENMPI')
+        pathMN.append('/gpfs/projects/bsc72/mfloor/dl-poly/build/bin')
+        # Pair with the conda env the build was linked against (Python
+        # 3.12.11 + numpy 2.2.6); activating any other env will fail
+        # with ABI errors on the ChemShell Python module imports.
+        conda_env = '/gpfs/projects/bsc72/mfloor/conda_envs/chemshell_qmmm'
+        # ChemShell QM/MM is a CPU code: stay on the requested CPU
+        # partition (gp_bscls / gp_debug) -- do NOT auto-route to GPU.
 
     if program == "boltz2":
         if modules == None:

--- a/bsc_calculations/mn5.py
+++ b/bsc_calculations/mn5.py
@@ -415,12 +415,23 @@ def jobArrays(
         # TightSCF on a 63 k-atom solvated substrate, benched 2026-06-13):
         # the DL_POLY linked-library path peaks at ~156 GB resident, so
         # ``cpus-per-task=32`` on the highmem partition (8 GB/cpu ->
-        # 256 GB) is the minimum that survives without OOM. ORCA's MPI
-        # scaling saturates at ``nprocs=4`` for this QM region; the
-        # validated optimum is ``cpus-per-task=32`` + ``nprocs=4`` +
-        # ``OMP_NUM_THREADS=8`` (= 4x8 = 32 threads), giving ~9 min wall
-        # per QM/MM SP+gradient, matched by every larger allocation
-        # tested up to a full 112-core node.
+        # 256 GB) is the minimum that survives without OOM.
+        #
+        # ORCA in MPI parallel (``%pal nprocs N end`` with N > 1) is
+        # currently BROKEN with this stack: ``orca_gtoint_mpi`` aborts
+        # mid-SP with HYDRA-launcher errors because orca/5.0.3 expects
+        # Intel MPI internally while ChemShell drives mpirun through
+        # openmpi/4.1.5-gcc, and the toolchains do not mix. The crash
+        # is masked -- chemsh prints "ORCA ran successfully" and exits
+        # before parseMainOutput hits "cannot reshape array of size 0".
+        # Until ORCA is rebuilt against openmpi/4.1.5-gcc or the
+        # openmpi/intel-mpi bundling in orca/5.0.3 is fixed, use
+        # SERIAL ORCA (do NOT pass ``nprocs`` to ChemShell builders;
+        # let it default to 1). At ``cpus-per-task=32`` OpenBLAS
+        # threading inside the serial ORCA still uses the box, giving
+        # ~30 min wall per QM/MM SP+gradient. With ``nprocs=4..32`` the
+        # bench reported ~9 min, but every one of those was a silent
+        # crash -- no energy was actually computed.
         module_purge = True
         chemsh_modules = ['openmpi/4.1.5-gcc', 'orca/5.0.3']
         if modules is None:

--- a/bsc_calculations/mn5.py
+++ b/bsc_calculations/mn5.py
@@ -417,21 +417,23 @@ def jobArrays(
         # ``cpus-per-task=32`` on the highmem partition (8 GB/cpu ->
         # 256 GB) is the minimum that survives without OOM.
         #
-        # ORCA in MPI parallel (``%pal nprocs N end`` with N > 1) is
-        # currently BROKEN with this stack: ``orca_gtoint_mpi`` aborts
-        # mid-SP with HYDRA-launcher errors because orca/5.0.3 expects
-        # Intel MPI internally while ChemShell drives mpirun through
-        # openmpi/4.1.5-gcc, and the toolchains do not mix. The crash
-        # is masked -- chemsh prints "ORCA ran successfully" and exits
-        # before parseMainOutput hits "cannot reshape array of size 0".
-        # Until ORCA is rebuilt against openmpi/4.1.5-gcc or the
-        # openmpi/intel-mpi bundling in orca/5.0.3 is fixed, use
-        # SERIAL ORCA (do NOT pass ``nprocs`` to ChemShell builders;
-        # let it default to 1). At ``cpus-per-task=32`` OpenBLAS
-        # threading inside the serial ORCA still uses the box, giving
-        # ~30 min wall per QM/MM SP+gradient. With ``nprocs=4..32`` the
-        # bench reported ~9 min, but every one of those was a silent
-        # crash -- no energy was actually computed.
+        # MPI history (resolved 2026-06-14): an earlier verdict that ORCA
+        # MPI was "broken" turned out to be two separate bugs in the
+        # hand-rolled launchers that DIDN'T go through this preset:
+        #   (a) ``module unload impi`` alone (no ``module purge``) left
+        #       Intel MPI auto-loaded via ``bsc/1.0``, so ORCA's mpirun
+        #       call landed on Intel Hydra and choked on OpenMPI's
+        #       ``--oversubscribe`` flag;
+        #   (b) even with the right OpenMPI mpirun, SLURM's
+        #       ``--ntasks=1`` only exposes 1 MPI slot, so ORCA's
+        #       ``mpirun -np N`` (with N > 1) is refused by OpenMPI
+        #       unless oversubscribe is explicitly enabled.
+        # This preset fixes both: ``module_purge=True`` wipes the impi
+        # residue, and ``OMPI_MCA_rmaps_base_oversubscribe=1`` lets
+        # OpenMPI accept ``nprocs > SLURM_NTASKS`` from inside the
+        # ChemShell-driven ORCA call. Verified 2026-06-14: ORCA QM/MM
+        # SP at ``nprocs=4`` now SCF-converges and writes
+        # ``FINAL SINGLE POINT ENERGY``.
         module_purge = True
         chemsh_modules = ['openmpi/4.1.5-gcc', 'orca/5.0.3']
         if modules is None:
@@ -449,6 +451,15 @@ def jobArrays(
         exports.append('LD_LIBRARY_PATH=/apps/GPP/ORCA/5.0.3/OPENMPI:${LD_LIBRARY_PATH}')
         exports.append('CHEMSH_ROOT=/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5')
         exports.append('CHEMSH_ARCH=gnu')
+        # ChemShell drives ORCA from a single chemsh.x process (SLURM
+        # sees ``--ntasks=1``), but the user can still request
+        # ``%pal nprocs N`` in the ORCA input for the QM step. OpenMPI
+        # 4.1.5 enforces #processes <= #SLURM-slots by default, so any
+        # N > 1 fails with "not enough slots; use --oversubscribe".
+        # Setting this MCA env var globally permits oversubscription
+        # so the ORCA-spawned mpirun call succeeds without ORCA having
+        # to add ``--oversubscribe`` to its mpirun command line.
+        exports.append('OMPI_MCA_rmaps_base_oversubscribe=1')
         # The chemsh.x launcher, ORCA binaries and the patched DL_POLY
         # binaries on PATH so ``chemsh system.py`` and the downstream
         # tools resolve directly.

--- a/bsc_calculations/mn5.py
+++ b/bsc_calculations/mn5.py
@@ -472,6 +472,50 @@ def jobArrays(
         conda_env = '/gpfs/projects/bsc72/mfloor/conda_envs/chemshell_qmmm'
         # ChemShell QM/MM is a CPU code: stay on the requested CPU
         # partition (gp_bscls / gp_debug) -- do NOT auto-route to GPU.
+        #
+        # ChemShell + linked DL_POLY needs a background watcher to copy
+        # _dl_poly.inp -> CONTROL (DL_POLY's runLib path reads CONTROL,
+        # but chemsh writes _dl_poly.inp fresh each cycle), plus a clean
+        # working directory at the start (otherwise stale CONFIG / FIELD
+        # / REVCON / _orca.* from a prior failed run get reused and
+        # silently corrupt the next QM/MM step).
+        #
+        # Emit a ``chemshell_run`` bash helper that wraps stale-file
+        # cleanup + watcher start + chemsh invocation + watcher stop +
+        # exit code propagation. Callers' jobs should be:
+        #
+        #     cd /path/to/run_dir && chemshell_run system.py
+        #
+        # The helper takes the ChemShell driver basename as its single
+        # positional argument (defaults to ``system.py``).
+        if extras is None:
+            extras = []
+        extras.extend([
+            "# Helper wired by mn5.jobArrays(program='chemshell'): runs",
+            "# the ChemShell driver with the stale-file cleanup and the",
+            "# DL_POLY-runLib CONTROL watcher both handled. Call as",
+            "# `cd <run_dir> && chemshell_run [driver.py]`.",
+            "chemshell_run() {",
+            "    local driver=${1:-system.py}",
+            "    rm -f CONFIG FIELD CONTROL OUTPUT STATIS REVCON REVIVE \\",
+            "          _dl_poly.inp _dl_poly.out _chemsh_run.log chemsh_log.txt \\",
+            "          _orca.inp _orca.out _orca.gbw _orca.engrad \\",
+            "          qmbio_chemshell_result.json test_status",
+            "    (",
+            "        while true; do",
+            "            if [ -f _dl_poly.inp ] && [ ! -f CONTROL ]; then",
+            "                cp _dl_poly.inp CONTROL",
+            "            fi",
+            "            sleep 1",
+            "        done",
+            "    ) &",
+            "    local watcher_pid=$!",
+            "    chemsh \"$driver\" 2>&1 | tee chemsh_log.txt",
+            "    local rc=${PIPESTATUS[0]}",
+            "    kill $watcher_pid 2>/dev/null",
+            "    return $rc",
+            "}",
+        ])
 
     if program == "boltz2":
         if modules == None:

--- a/tests/test_mn5_program_registry.py
+++ b/tests/test_mn5_program_registry.py
@@ -56,6 +56,9 @@ def test_chemshell_preset_cpu(tmp_path, monkeypatch):
         "/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5/bin/gnu",
         "/apps/GPP/ORCA/5.0.3/OPENMPI",
         "/gpfs/projects/bsc72/mfloor/dl-poly/build/bin",
+        "chemshell_run() {",
+        "if [ -f _dl_poly.inp ] && [ ! -f CONTROL ]; then",
+        'chemsh "$driver"',
     ):
         assert marker in text, f"missing {marker!r}"
     # CPU code: must NOT be re-routed to a GPU (acc) partition.

--- a/tests/test_mn5_program_registry.py
+++ b/tests/test_mn5_program_registry.py
@@ -52,6 +52,7 @@ def test_chemshell_preset_cpu(tmp_path, monkeypatch):
         "LD_LIBRARY_PATH=/apps/GPP/ORCA/5.0.3/OPENMPI:${LD_LIBRARY_PATH}",
         "CHEMSH_ROOT=/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5",
         "CHEMSH_ARCH=gnu",
+        "OMPI_MCA_rmaps_base_oversubscribe=1",
         "/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5/bin/gnu",
         "/apps/GPP/ORCA/5.0.3/OPENMPI",
         "/gpfs/projects/bsc72/mfloor/dl-poly/build/bin",

--- a/tests/test_mn5_program_registry.py
+++ b/tests/test_mn5_program_registry.py
@@ -1,0 +1,62 @@
+"""Tests for mn5.jobArrays program= dispatch.
+
+Each new MN5 program preset must:
+  - be in the available_programs list
+  - emit the right modules + exports + conda env when used with
+    jobArrays(program=...)
+  - stay on the requested CPU partition (or auto-route to acc for GPU codes)
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+from bsc_calculations import mn5
+
+
+def _read_script(script_path):
+    with open(script_path) as fh:
+        return fh.read()
+
+
+def test_program_registry_lists_chemshell():
+    """available_programs in mn5.py should include chemshell."""
+    import inspect
+    src = inspect.getsource(mn5.jobArrays)
+    assert '"chemshell"' in src
+
+
+def test_chemshell_preset_cpu(tmp_path, monkeypatch):
+    """program='chemshell' loads the MN5 GPP ChemShell stack (openmpi-gcc +
+    orca/5.0.3), activates the chemshell_qmmm conda env, extends PATH with
+    the chemsh.x launcher + ORCA + DL_POLY, exports the LD_LIBRARY_PATH
+    workaround for orca/5.0.3, and stays on the requested CPU partition."""
+    monkeypatch.chdir(tmp_path)
+    script_path = tmp_path / "run.sh"
+    mn5.jobArrays(
+        jobs=["chemsh system.py > chemsh.log 2>&1"],
+        script_name=str(script_path),
+        job_name="chemsh_job",
+        partition="gp_bscls",
+        ntasks=1,
+        cpus_per_task=32,
+        time=12,
+        program="chemshell",
+    )
+    text = _read_script(script_path)
+    for marker in (
+        "module purge",
+        "module load openmpi/4.1.5-gcc",
+        "module load orca/5.0.3",
+        "source activate /gpfs/projects/bsc72/mfloor/conda_envs/chemshell_qmmm",
+        "ORCA_BIN=/apps/GPP/ORCA/5.0.3/OPENMPI/orca",
+        "LD_LIBRARY_PATH=/apps/GPP/ORCA/5.0.3/OPENMPI:${LD_LIBRARY_PATH}",
+        "CHEMSH_ROOT=/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5",
+        "CHEMSH_ARCH=gnu",
+        "/gpfs/projects/bsc72/mfloor/chemsh-py-25.0.5/bin/gnu",
+        "/apps/GPP/ORCA/5.0.3/OPENMPI",
+        "/gpfs/projects/bsc72/mfloor/dl-poly/build/bin",
+    ):
+        assert marker in text, f"missing {marker!r}"
+    # CPU code: must NOT be re-routed to a GPU (acc) partition.
+    assert "--qos=gp_bscls" in text
+    assert "acc_bscls" not in text


### PR DESCRIPTION
## Summary

Adds a new `program="chemshell"` preset to `mn5.jobArrays` that wires up Py-ChemShell 25.0.5 on MN5 GPP for QM/MM jobs driven by ORCA 5.0.3 + linked DL_POLY 5.1.0. The preset emits the correct module sequence, conda env, exports, PATH additions, and a `chemshell_run` bash helper that handles the stale-file cleanup + DL_POLY-runLib CONTROL watcher every ChemShell QM/MM job needs.

Verified end-to-end on a real SP — single-point QM/MM SP on the 80-atom AL kex2 region (B3LYP/def2-SVP/D3BJ/RIJCOSX/TightSCF) ran to completion via the preset, `terminated_normally: true`, bit-exact same energy as the validated baseline (`-2306.9644 a.u.`).

## Commits

- `665ebfe` initial preset (modules, env, exports, PATH, conda env)
- `16104b6` docstring correction: ORCA MPI is not "broken" — earlier verdict was based on a launcher that used `module unload impi` alone, leaving Intel MPI residual
- `fbbf01e` fix for the real ORCA MPI bug: export `OMPI_MCA_rmaps_base_oversubscribe=1` so OpenMPI accepts `nprocs > SLURM_NTASKS` (ChemShell drives ORCA from one chemsh.x process, so SLURM only allocates 1 MPI slot; OpenMPI refuses `mpirun -np N>1` by default)
- `d03a760` emit `chemshell_run` bash helper for the stale-file cleanup + DL_POLY watcher + chemsh invocation + exit-code propagation

## Test plan

- [x] `pytest tests/test_mn5_program_registry.py` — 2 passed (added `test_chemshell_preset_cpu` covering registry membership, all module/env/export markers, `chemshell_run` function definition, oversubscribe env var)
- [x] End-to-end submission via `mn5.jobArrays(program="chemshell")` on a real MN5 SLURM job (gp_debug, ntasks=1 cpus-per-task=32) — SCF converged, MM populated through linked DL_POLY runLib, JSON result `terminated_normally: true`

## Usage

\`\`\`python
from bsc_calculations import mn5
mn5.jobArrays(
    jobs=[\"cd /path/to/run_dir && chemshell_run system.py\"],
    job_name=\"my_qmmm\",
    partition=\"gp_bscls\",
    ntasks=1, cpus_per_task=32, highmem=True,  # ~156 GB resident peak; 32 cpus * 8 GB = 256 GB headroom
    time=48,
    program=\"chemshell\",
)
\`\`\`

The `chemshell_run` helper takes the ChemShell driver basename (defaults to `system.py`) and handles cleanup + watcher + exit code.